### PR TITLE
test: refactoring variables -  let method

### DIFF
--- a/lib/board.rb
+++ b/lib/board.rb
@@ -5,7 +5,8 @@ class Board
   attr_reader :cells, :place
   
   def initialize(custom = false)#we did not need cells in the () as we dont actually use it
-    @cells = {}
+    @cells = 
+    {}
     if custom
       puts "How many collumns?"
       @col = gets.chomp
@@ -51,7 +52,6 @@ class Board
     elsif !placements.all? { |dot| @cells[dot].empty? }     
       return false
     end
-    
     return true
   end
 
@@ -68,8 +68,4 @@ class Board
     "C #{@cells["C1"].render(actual)} #{@cells["C2"].render(actual)} #{@cells["C3"].render(actual)} #{@cells["C4"].render(actual)} \n" +
     "D #{@cells["D1"].render(actual)} #{@cells["D2"].render(actual)} #{@cells["D3"].render(actual)} #{@cells["D4"].render(actual)} \n"
   end
-
-
-  end
-
 end

--- a/lib/game.rb
+++ b/lib/game.rb
@@ -1,0 +1,23 @@
+
+class Game
+#can put option here so that it runs every time game class is called
+
+  # attr_reader :welcome, :choice
+  def initialize()
+    # @welcome = "Welcome to BATTLESHIP"
+    # @choice = "Enter p to play. Enter q to quit." 
+  end
+
+
+  def messages
+    welcome = "Welcome to BATTLESHIP \n"
+    choice = "Enter p to play. Enter q to quit."
+    puts welcome + choice 
+    return welcome + choice 
+  end
+
+
+
+end
+
+# puts @messages

--- a/spec/board_spec.rb
+++ b/spec/board_spec.rb
@@ -4,25 +4,23 @@ require './lib/ship'
 require './lib/cell'
 
 RSpec.describe Board do
-  before :each do
-    @board = Board.new()
-  end
+    let(:board) { Board.new() }
 
   it 'class should exist' do
-    expect(@board).to be_an_instance_of(Board)
+    expect(board).to be_an_instance_of(Board)
   end
 
   it 'the cells should be link back to the Cell class'do
-    expect(@board.cells['A1']).to be_an_instance_of Cell
+    expect(board.cells['A1']).to be_an_instance_of Cell
   end #cells are coordinates on the board
 
   it 'should inform if a coordinate is on the board' do
-    expect(@board.valid_coordinate?('A1')).to eq(true)
-    expect(@board.valid_coordinate?('D4')).to eq(true)
-    expect(@board.valid_coordinate?('A5')).to eq(false)
-    expect(@board.valid_coordinate?('E1')).to eq(false)
-    expect(@board.valid_coordinate?('A22')).to eq(false)
-    expect(@board.valid_coordinate?('a1')).to eq(false)
+    expect(board.valid_coordinate?('A1')).to eq(true)
+    expect(board.valid_coordinate?('D4')).to eq(true)
+    expect(board.valid_coordinate?('A5')).to eq(false)
+    expect(board.valid_coordinate?('E1')).to eq(false)
+    expect(board.valid_coordinate?('A22')).to eq(false)
+    expect(board.valid_coordinate?('a1')).to eq(false)
   end
 
   it 'should inform if a placement for a ship on the board is valid or not' do
@@ -34,29 +32,29 @@ RSpec.describe Board do
     expect(submarine.length).to eq(["B1", "C1"].length)
 
     #coordinates are consecutive
-    expect(@board.valid_placement?(cruiser, ["A1", "A2", "A5"])).to eq(false)
-    expect(@board.valid_placement?(submarine, ["B1", "D1"])).to eq(false)
-    expect(@board.valid_placement?(cruiser, ["A3", "A2", "A1"])).to eq(false)
-    expect(@board.valid_placement?(submarine, ["C1", "B1"])).to eq(false)
+    expect(board.valid_placement?(cruiser, ["A1", "A2", "A5"])).to eq(false)
+    expect(board.valid_placement?(submarine, ["B1", "D1"])).to eq(false)
+    expect(board.valid_placement?(cruiser, ["A3", "A2", "A1"])).to eq(false)
+    expect(board.valid_placement?(submarine, ["C1", "B1"])).to eq(false)
 
     #coordinates are not diagonal
-    expect(@board.valid_placement?(cruiser, ["A1", "B2", "C3"])).to eq(false)
-    expect(@board.valid_placement?(cruiser, ["C2", "D3"])).to eq(false)
+    expect(board.valid_placement?(cruiser, ["A1", "B2", "C3"])).to eq(false)
+    expect(board.valid_placement?(cruiser, ["C2", "D3"])).to eq(false)
 
     #valid placements
-    expect(@board.valid_placement?(cruiser, ["B1", "C1", "D1"])).to eq(true)
-    expect(@board.valid_placement?(submarine, ["A1", "A2"])).to eq(true)
+    expect(board.valid_placement?(cruiser, ["B1", "C1", "D1"])).to eq(true)
+    expect(board.valid_placement?(submarine, ["A1", "A2"])).to eq(true)
   end
 
 
   it 'the board should be able to place a ship in its cells' do
     #multiple Cells will contain the same ship
     cruiser = Ship.new("Cruiser", 3)
-    @board.place(cruiser, ["A1", "A2", "A3"])
+    board.place(cruiser, ["A1", "A2", "A3"])
 
-    cell_1 = @board.cells["A1"]
-    cell_2 = @board.cells["A2"]
-    cell_3 = @board.cells["A3"]
+    cell_1 = board.cells["A1"]
+    cell_2 = board.cells["A2"]
+    cell_3 = board.cells["A3"]
 
     expect(cell_3.ship == cell_2.ship).to eq true
     expect(cell_2.ship == cell_1.ship).to eq true
@@ -67,24 +65,24 @@ RSpec.describe Board do
 
   it 'valid placements checks if a ship would overlap with another' do
     cruiser = Ship.new("Cruiser", 3)
-    @board.place(cruiser, ["A1", "A2", "A3"])
+    board.place(cruiser, ["A1", "A2", "A3"])
     # require 'pry';binding.pry
 
     submarine = Ship.new("Submarine", 2)
-    expect(@board.valid_placement?(submarine, ["A1", "B1"])).to eq(false)
+    expect(board.valid_placement?(submarine, ["A1", "B1"])).to eq(false)
   end
 
   it 'render prints out the whole board' do
     cruiser = Ship.new("Cruiser", 3)
-    @board.place(cruiser, ["A1", "A2", "A3"])
-    expect(@board.render).to eq(
+    board.place(cruiser, ["A1", "A2", "A3"])
+    expect(board.render).to eq(
       "  1 2 3 4 \n" +
       "A . . . . \n" +
       "B . . . . \n" +
       "C . . . . \n" +
       "D . . . . \n"
     )
-    expect(@board.render(true)).to eq(
+    expect(board.render(true)).to eq(
       "  1 2 3 4 \n" +
       "A S S S . \n" +
       "B . . . . \n" +
@@ -93,9 +91,12 @@ RSpec.describe Board do
     )
   end
 
+  #***!!
+  #this test is failing at the moment 
+  #!!***
   it 'renders any size board' do
     custom_board = Board.new(true)
-    expect(@board.render).to eq(
+    expect(board.render).to eq(
       "  1 2 3 4 5 \n" +
       "A . . . . . \n" +
       "B . . . . . \n" +
@@ -107,18 +108,18 @@ RSpec.describe Board do
 
 it 'should display the cells status in a formatted grid. ' do
   cruiser = Ship.new("Cruiser", 3)
-  @board.place(cruiser, ["A1", "A2", "A3"])
+  board.place(cruiser, ["A1", "A2", "A3"])
   # require 'pry';binding.pry
 
-  expect(@board.render).to eq(
+  expect(board.render).to eq(
   "  1 2 3 4 \n" +
   "A . . . . \n" +
   "B . . . . \n" +
   "C . . . . \n" +
   "D . . . . \n")
-  @board.place(cruiser, ["A1", "A2", "A3"])
+  board.place(cruiser, ["A1", "A2", "A3"])
   # require 'pry';binding.pry
-  expect(@board.render(true)).to eq(
+  expect(board.render(true)).to eq(
   "  1 2 3 4 \n" +
   "A S S S . \n" +
   "B . . . . \n" +

--- a/spec/cell_spec.rb
+++ b/spec/cell_spec.rb
@@ -1,15 +1,22 @@
-crequire './lib/cell' #confirm the file name
+require './lib/cell' #confirm the file name
 
 RSpec.describe Cell do
+  let(:cell_1) { Cell.new("A1") }
+  let(:cell_2) { Cell.new("A2") }
+  let(:cell_3) { Cell.new("A3") }
+  let(:cell_4) { Cell.new("A4") }
+  let(:cell_5) { Cell.new("A5") } 
+  let(:ship_1) { Ship.new("Cruiser", 3) } 
+
   it 'Cell class should exist' do
-    cell_1 = Cell.new("A1")
+    cell_1
     expect(cell_1).to be_an_instance_of(Cell)
     expect(cell_1.empty?).to eq(true)
   end
 
   it 'Cell can place ship' do
-    ship_1 = Ship.new("Cruiser", 3)
-    cell_1 = Cell.new("A1")
+    ship_1
+    cell_1
     cell_1.place_ship(ship_1)
 
     expect(cell_1.ship).to eq(ship_1)
@@ -17,8 +24,8 @@ RSpec.describe Cell do
   end
 
   it 'Cell can be fired upon' do
-    ship_1 = Ship.new("Cruiser", 3)
-    cell_1 = Cell.new("A1")
+    ship_1
+    cell_1
     expect(cell_1.fired_upon?).to eq(false)
     cell_1.place_ship(ship_1)
 
@@ -28,13 +35,13 @@ RSpec.describe Cell do
   end
 
   it 'Cell can render' do
-    cell_1 = Cell.new("A1")
-    cell_2 = Cell.new("A2")
-    cell_3 = Cell.new("A3")
-    cell_4 = Cell.new("A4")
-    cell_5 = Cell.new("A5")
+    cell_1
+    cell_2
+    cell_3
+    cell_4
+    cell_5
 
-    ship_1 = Ship.new("Cruiser", 3)
+    ship_1
 
     expect(cell_1.render).to eq(".")
 
@@ -53,7 +60,5 @@ RSpec.describe Cell do
 
     cell_5.fire_upon
     expect(cell_5.render).to eq("X")
-
-    # require 'pry'; binding.pry
   end
 end

--- a/spec/game_spec.rb
+++ b/spec/game_spec.rb
@@ -1,14 +1,26 @@
 require './lib/game'
 
 RSpec.describe Game do
+  before :each do
+    @game = Game.new
+  end
+  
+  
   it 'Game exists' do
-    game = Game.new
-    expect(game).to be_an_instance_of(Game)
+    expect(@game).to be_an_instance_of Game
   end
 
   it 'Game has a welcome message' do
-    game = Game.new
-    expect(game).to output('Welcome to BATTLESHIP').to_stdout
-    expect(game).to output('Enter p to play. Enter q to quit.').to_stdout
-  end
+    # expect(@game.welcome).to eq('Welcome to BATTLESHIP')
+    expect(@game.messages).to eq(
+    "Welcome to BATTLESHIP \n" + 
+    "Enter p to play. Enter q to quit.")
+    require 'pry';binding.pry
+    end
+
+    # it '' do
+    #   expect 
+    # end
+
+
 end

--- a/spec/ship_spec.rb
+++ b/spec/ship_spec.rb
@@ -1,82 +1,80 @@
 require './lib/ship'
 
 RSpec.describe Ship do
-  before :each do
-    @boat_1 = Ship.new('Cruiser', 3)
-    @boat_2 = Ship.new('Submarine', 2)
-  end
+  let(:boat_1) { Ship.new('Cruiser', 3) } 
+  let(:boat_2) { Ship.new('Submarine', 2) } 
 
   it 'Ship class should exist'do
-    expect(@boat_1).to be_an_instance_of(Ship)
+    expect(boat_1).to be_an_instance_of(Ship)
   end
 
   it '@boats should have unique names'do
-    expect(@boat_1.name).to eq('Cruiser')
-    expect(@boat_2.name).to eq('Submarine')
+    expect(boat_1.name).to eq('Cruiser')
+    expect(boat_2.name).to eq('Submarine')
   end
 
   it '@boats should have a unique lenghts'do
-    expect(@boat_1.length).to eq(3)
-    expect(@boat_2.length).to eq(2)
+    expect(boat_1.length).to eq(3)
+    expect(boat_2.length).to eq(2)
   end
 
   it'should inform boat health'do
-    expect(@boat_1.health).to eq(3)
-    expect(@boat_2.health).to eq(2)
+    expect(boat_1.health).to eq(3)
+    expect(boat_2.health).to eq(2)
   end
 
   it'should inform if boat is hit'do
-      @boat_1.hit
-    expect(@boat_1.health).to eq(2)
-      @boat_2.hit
-    expect(@boat_2.health).to eq(1)
+      boat_1.hit
+    expect(boat_1.health).to eq(2)
+      boat_2.hit
+    expect(boat_2.health).to eq(1)
   end
 
   it'should inform if boat is sunk'do
-    expect(@boat_1.sunk?).to eq(false)
-    expect(@boat_2.sunk?).to eq(false)
-      @boat_1.hit
-      @boat_1.hit
-      @boat_1.hit
-    expect(@boat_1.sunk?).to eq(true)
+    expect(boat_1.sunk?).to eq(false)
+    expect(boat_2.sunk?).to eq(false)
+      boat_1.hit
+      boat_1.hit
+      boat_1.hit
+    expect(boat_1.sunk?).to eq(true)
   end
 
   context 'Ship basic characteristics'do
     it'Ship class should exist'do
-      expect(@boat_1).to be_an_instance_of (Ship)
+      expect(boat_1).to be_an_instance_of (Ship)
     end
 
     it'@boats should have unique names'do
-      expect(@boat_1.name).to eq('Cruiser')
-      expect(@boat_2.name).to eq('Submarine') 
+      expect(boat_1.name).to eq('Cruiser')
+      expect(boat_2.name).to eq('Submarine') 
     end
 
     it'@boats should have a unique lenghts'do
-      expect(@boat_1.length).to eq(3)
-      expect(@boat_2.length).to eq(2)
+      expect(boat_1.length).to eq(3)
+      expect(boat_2.length).to eq(2)
     end
   end
 
   context 'check the status of the boats within the game'do
     it'should inform boat health'do
-      expect(@boat_1.health).to eq(3)
-      expect(@boat_2.health).to eq(2)
+      expect(boat_1.health).to eq(3)
+      expect(boat_2.health).to eq(2)
     end
 
     it'should inform if boat is hit'do
-        @boat_1.hit  
-      expect(@boat_1.health).to eq(2)
-        @boat_2.hit
-      expect(@boat_2.health).to eq(1)
+        boat_1.hit  
+      expect(boat_1.health).to eq(2)
+        boat_2.hit
+      expect(boat_2.health).to eq(1)
     end
 
     it'should inform if boat is sunk'do
-      expect(@boat_1.sunk?).to eq(false)
-      expect(@boat_2.sunk?).to eq(false)
-        @boat_1.hit 
-        @boat_1.hit 
-        @boat_1.hit 
-      expect(@boat_1.sunk?).to eq(true)
+      expect(boat_1.sunk?).to eq(false)
+      expect(boat_2.sunk?).to eq(false)
+        boat_1.hit 
+        boat_1.hit 
+        boat_1.hit 
+      expect(boat_1.sunk?).to eq(true)
     end
   end
 end


### PR DESCRIPTION
hey, 
note: in board_spec we have a test failing ('renders any size board')... let's review that.

also, this push is to refactor the tests to use the _let_(:) method instead of _Before :each_ or having variables in each test.

centralizing/block-ing the variables makes it easier to read and we also have 1 place to go if we need to make a change to a variable (for whatever reason).
_let_ is passive method, so variables only run when called upon. _Before :each_ ran the variables during each tests (even if they were not called upon.

here's an article with more on _let_ :
https://stackoverflow.com/questions/5359558/when-to-use-rspec-let